### PR TITLE
[Feat] - Added Confirmation PopUp for Remove Editor Button

### DIFF
--- a/src/components/UiSections/Channel/Editor/EditorCard.tsx
+++ b/src/components/UiSections/Channel/Editor/EditorCard.tsx
@@ -1,14 +1,39 @@
 import Button from "@/components/Buttons/Button"
+import PopUpModal from "@/components/Modal/PopUpModal"
 import { UserBasicDetailsType } from "@/utils/types/user"
 import Image from "next/image"
-import React from "react"
+import React, { useState } from "react"
 import { RiDeleteBack2Line } from "react-icons/ri"
 
 function EditorCard({ editor }: { editor: UserBasicDetailsType }) {
-    console.log(editor.image)
-
+    console.log(editor?.image)
+    const [isOpen, setIsOpen] = useState<boolean>(false);
     return (
         <div className="w-full flex items-center justify-between h-24 bg-secondary-hover px-4 rounded-xl">
+            <PopUpModal
+                isOpen={isOpen}
+                closeModal={() => {
+                    setIsOpen(false)
+                }}
+            >
+                <div className="w-full flex justify-start items-center flex-col p-3">
+                    <div className="flex justify-center items-center">
+                        Are you sure you want to remove this Editor?
+                    </div>
+                    <div className="flex justify-between items-center text-white w-full">
+                        <Button
+                            className="p-2 text-sm md:text-base"
+                            text="No"
+                            onClick={() => setIsOpen(false)}
+                        />
+                        <Button
+                            className="p-2 bg-green-400 border-none hover:bg-green-500 text-sm md:text-base"
+                            text="Yes"
+                        />
+                    </div>
+                </div>
+            </PopUpModal>
+
             <div className="flex items-center justify-center gap-2">
                 <Image
                     width={60}
@@ -29,6 +54,7 @@ function EditorCard({ editor }: { editor: UserBasicDetailsType }) {
                 icon={<RiDeleteBack2Line />}
                 text="remove"
                 className="btn_1_2"
+                onClick={() => setIsOpen(true)}
             />
         </div>
     )


### PR DESCRIPTION
This pull request implements a confirmation popup for the "Remove Editor" button, as outlined in issue #18 . The popup ensures that users receive a prompt to confirm their action before an editor is removed

## Changes Included
-  Added a confirmation popup when the "Remove Editor" button is clicked.
-  Implemented the frontend part only as per mentioned.

## Issue Fixed
This pull request closes #18  by addressing the requirement for a confirmation step when removing an editor.

 